### PR TITLE
📝 add `cargo docs` to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ env:
   global:
     - PROJECT_NAME: fastlz
     - RUST_BACKTRACE: full
+script:
+  - cargo build --verbose --all
+  - cargo test --verbose --all
+  - cargo doc --verbose --all
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
By default travis just does `cargo test`-
https://docs.travis-ci.com/user/languages/rust/#default-build-script

Also add `cargo build` to travis.